### PR TITLE
Fix syntex benchmarks

### DIFF
--- a/syntex-0.42.2-incr-clean/Cargo.toml
+++ b/syntex-0.42.2-incr-clean/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 
 [dependencies]
-syntex = "0.42.2"
+syntex = "= 0.42.2"

--- a/syntex-0.42.2-incr-clean/makefile
+++ b/syntex-0.42.2-incr-clean/makefile
@@ -1,10 +1,19 @@
 .PHONY: all touch clean
 
+# The way that this is intended to work is as follows:
+# - We force the incremental data to be stored in the `incr` directory
+# - We clean precisely the syntex_syntax crate; but we do not touch the `incr` directory
+# - We rebuild, which will reuse the results from `incr` directory
+#
+# This can be compared against `syntex-0.42.2`, which does the same
+# thing, but without the `incr` directory.
+
 all:
-	RUSTFLAGS="-Z incremental=incr -Z incremental-info" cargo rustc -- $(CARGO_RUSTC_OPTS)
+	RUSTFLAGS="-Z incremental=incr" \
+	    cargo rustc -p syntex_syntax -- $(CARGO_RUSTC_OPTS) -Z incremental-info
 touch:
-	cargo clean # note: leave the `incr` directory alone
+	cargo clean -p syntex_syntax
 clean:
 	rm -rf incr/*
 	cargo clean
-	rm Cargo.lock
+

--- a/syntex-0.42.2/Cargo.toml
+++ b/syntex-0.42.2/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 
 [dependencies]
-syntex = "0.42.2"
+syntex = "= 0.42.2"

--- a/syntex-0.42.2/makefile
+++ b/syntex-0.42.2/makefile
@@ -1,9 +1,12 @@
 .PHONY: all touch clean
 
+# Time how long it takes to build `syntex_syntax`. See
+# `../syntax-0.42.2-incr-clean/makefile` for some further notes.
+
 all:
-	cargo rustc -- $(CARGO_RUSTC_OPTS)
+	cargo rustc -p syntex_syntax -- $(CARGO_RUSTC_OPTS)
 touch:
-	find . -name '*.rs' | xargs touch
+	cargo clean -p syntex_syntax
 clean:
 	cargo clean
-	rm Cargo.lock
+


### PR DESCRIPTION
This tweaks the syntex benchmarks. I think the current definition is both a touch cleaner and compatible with the process.sh and compare-script as well. Since it's based on @nnethercote's branch, I'm opening a PR against his repo. 
